### PR TITLE
Updated to cover box and sign

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/lvh/caesium"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.abstractj.kalium/kalium "0.3.0" :scope "compile"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.abstractj.kalium/kalium "0.4.0" :scope "compile"]]
   :main ^:skip-aot caesium.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -6,9 +6,9 @@
            org.abstractj.kalium.crypto.Box))
 
 (defn generate-keypair
-  "Generate a secret-key and corresponding public-key with `crypto_box_keypair`.
-  
-  If secret-key is provided as an argument, generate the corresponding public-key with `crypto_scalarmult_base`.
+  "Generate a secret-key and corresponding public-key with `crypto_box_curve25519xsalsa20poly1305_keypair`.
+
+  If secret-key is provided as an argument, generate the corresponding public-key with `crypto_scalarmult_curve25519`.
 
   Returns a map containing the public and private key bytes (mutable arrays)."
   ([]
@@ -21,7 +21,7 @@
       :secret secret-key})))
 
 (defn encrypt
-  "Encrypt with `crypto_box_easy`.
+  "Encrypt with `crypto_box_curve25519xsalsa20poly1305_beforenm` and `crypto_box_curve25519xsalsa20poly1305_afternm`.
 
   Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
   [^bytes public-key
@@ -33,7 +33,7 @@
     (.encrypt (Box. pbk pvk) nonce plaintext)))
 
 (defn decrypt
-  "Decrypt with `crypto_box_easy_open`.
+  "Decrypt with `crypto_box_curve25519xsalsa20poly1305_beforenm` and `crypto_box_curve25519xsalsa20poly1305_open_afternm`.
 
   Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
   [^bytes public-key

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -1,0 +1,29 @@
+(ns caesium.crypto.box
+  "Bindings to the public-key authenticated encryption scheme."
+  (:import (org.abstractj.kalium.keys PublicKey
+                                      PrivateKey)
+           org.abstractj.kalium.crypto.Box))
+
+(defn encrypt
+  "Encrypt with `crypto_box_easy`.
+
+  Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
+  [^bytes public-key
+   ^bytes private-key
+   nonce
+   plaintext]
+  (let [pbk (PublicKey. public-key)
+        pvk (PrivateKey. private-key)]
+    (.encrypt (Box. pbk pvk) nonce plaintext)))
+
+(defn decrypt
+  "Decrypt with `crypto_box_easy_open`.
+
+  Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
+  [^bytes public-key
+   ^bytes private-key
+   nonce
+   ciphertext]
+  (let [pbk (PublicKey. public-key)
+        pvk (PrivateKey. private-key)]
+    (.decrypt (Box. pbk pvk) nonce ciphertext)))

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -1,8 +1,24 @@
 (ns caesium.crypto.box
   "Bindings to the public-key authenticated encryption scheme."
-  (:import (org.abstractj.kalium.keys PublicKey
+  (:import (org.abstractj.kalium.keys KeyPair
+                                      PublicKey
                                       PrivateKey)
            org.abstractj.kalium.crypto.Box))
+
+(defn generate-keypair
+  "Generate a secret-key and corresponding public-key with `crypto_box_keypair`.
+  
+  If secret-key is provided as an argument, generate the corresponding public-key with `crypto_scalarmult_base`.
+
+  Returns a map containing the public and private key bytes (mutable arrays)."
+  ([]
+   (let [kp (KeyPair.)]
+     {:public (.toBytes (.getPublicKey kp))
+      :secret (.toBytes (.getPrivateKey kp)) }))
+  ([secret-key]
+   (let [kp (KeyPair. secret-key)]
+     {:public (.toBytes (.getPublicKey kp))
+      :secret secret-key})))
 
 (defn encrypt
   "Encrypt with `crypto_box_easy`.

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -25,11 +25,11 @@
 
   Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
   [^bytes public-key
-   ^bytes private-key
+   ^bytes secret-key
    nonce
    plaintext]
   (let [pbk (PublicKey. public-key)
-        pvk (PrivateKey. private-key)]
+        pvk (PrivateKey. secret-key)]
     (.encrypt (Box. pbk pvk) nonce plaintext)))
 
 (defn decrypt
@@ -37,9 +37,9 @@
 
   Please note that contrary to Kalium, it only accepts keys in byte array form. It also returns a mutable byte array."
   [^bytes public-key
-   ^bytes private-key
+   ^bytes secret-key
    nonce
    ciphertext]
   (let [pbk (PublicKey. public-key)
-        pvk (PrivateKey. private-key)]
+        pvk (PrivateKey. secret-key)]
     (.decrypt (Box. pbk pvk) nonce ciphertext)))

--- a/src/caesium/crypto/generichash.clj
+++ b/src/caesium/crypto/generichash.clj
@@ -14,3 +14,13 @@
                     personal sixteen-nuls
                     key empty-byte-array}}]
      (.blake2 (new Hash) message key salt personal)))
+
+(defn sha256
+  "Computes the SHA-256 digest of the given message with `crypto_hash_sha256`."
+  [message]
+  (.sha256 (Hash.) message))
+
+(defn sha512
+  "Computes the SHA-512 digest of the given message with `crypto_hash_sha512`."
+  [message]
+  (.sha512 (Hash.) message))

--- a/src/caesium/crypto/sign.clj
+++ b/src/caesium/crypto/sign.clj
@@ -1,0 +1,26 @@
+(ns caesium.crypto.sign
+  (:import (org.abstractj.kalium.keys SigningKey
+                                      VerifyKey)))
+
+(defn generate-signing-keys
+  "Generate a public-key and secret-key for signing with `crypto_sign_ed25519_seed_keypair`. If a seed is not provided, one is taken from `randombytes`.
+
+  A map of the secret seed and public-key is returned."
+  ([]
+   (let [sk (SigningKey.)]
+     {:secret (.toBytes sk)
+      :public (.toBytes (.getVerifyKey sk))}))
+  ([seed]
+   (let [sk (SigningKey. seed)]
+     {:secret seed
+      :public (.toBytes (.getVerifyKey sk))})))
+
+(defn sign
+  "Sign a message using `crypto_sign_ed25519`."
+  [secret-seed message]
+  (.sign (SigningKey. secret-seed) message))
+
+(defn verify
+  "Verify a signature using `crypto_sign_ed25519_open`."
+  [public-key message signature]
+  (.verify (VerifyKey. public-key) message signature))

--- a/src/caesium/util.clj
+++ b/src/caesium/util.clj
@@ -1,13 +1,13 @@
 (ns caesium.util
-  (:import (java.util Arrays)))
+  (:import (java.util Arrays)
+           (org.abstractj.kalium.encoders Encoder)))
 
 (defn array-eq [^bytes a ^bytes b]
   "Compares two byte arrays for equality."
   (Arrays/equals a b))
 
 (defn unhexify [s]
-  (let [encoded-bytes (partition 2 s)
-        hex-pair->int (fn [[x y]]
-                        (unchecked-byte (Integer/parseInt (str x y) 16)))
-        decoded-bytes (map hex-pair->int encoded-bytes)]
-    (into-array Byte/TYPE decoded-bytes)))
+  (.decode Encoder/HEX s))
+
+(defn hexify [b]
+  (.encode Encoder/HEX b))

--- a/test/caesium/crypto/box_test.clj
+++ b/test/caesium/crypto/box_test.clj
@@ -1,0 +1,36 @@
+(ns caesium.crypto.box-test
+  (:require [caesium.crypto.box :refer :all]
+            [caesium.util :refer :all]
+            [clojure.test :refer :all]))
+
+;; These test values taken from Kalium
+(def nonce
+  (unhexify "69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37"))
+(def plaintext
+  (unhexify "be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffce5ecbaaf33bd751a1ac728d45e6c61296cdc3c01233561f41db66cce314adb310e3be8250c46f06dceea3a7fa1348057e2f6556ad6b1318a024a838f21af1fde048977eb48f59ffd4924ca1c60902e52f0a089bc76897040e082f937763848645e0705"))
+(def ciphertext 
+  (unhexify "f3ffc7703f9400e52a7dfb4b3d3305d98e993b9f48681273c29650ba32fc76ce48332ea7164d96a4476fb8c531a1186ac0dfc17c98dce87b4da7f011ec48c97271d2c20f9b928fe2270d6fb863d51738b48eeee314a7cc8ab932164548e526ae90224368517acfeabd6bb3732bc0e9da99832b61ca01b6de56244a9e88d5f9b37973f622a43d14a6599b1f654cb45a74e355a5"))
+
+(def bob-private-key 
+  (unhexify "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"))
+(def bob-public-key 
+  (unhexify "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"))
+
+(def alice-private-key 
+  (unhexify "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"))
+(def alice-public-key 
+  (unhexify "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"))
+
+(deftest box-encrypt-decrypt-test
+  (testing "Bob can encrypt a message for Alice"
+    (is (array-eq ciphertext
+                  (encrypt alice-public-key bob-private-key nonce plaintext))))
+  (testing "Alice can decrypt the message from Bob"
+    (is (array-eq plaintext
+                  (decrypt bob-public-key alice-private-key nonce ciphertext))))
+  (testing "No hex please"
+    (is (thrown? java.lang.ClassCastException
+                 (encrypt (hexify alice-public-key)
+                          (hexify bob-private-key)
+                          nonce
+                          plaintext)))))

--- a/test/caesium/crypto/box_test.clj
+++ b/test/caesium/crypto/box_test.clj
@@ -3,7 +3,19 @@
             [caesium.util :refer :all]
             [clojure.test :refer :all]))
 
-;; These test values taken from Kalium
+(deftest box-keypair-generation
+  (testing "Simply generates new keypairs"
+    (is (let [kp1 (generate-keypair)
+              kp2 (generate-keypair)]
+          (and (not (array-eq (:public kp1) (:public kp2)))
+               (not (array-eq (:secret kp1) (:secret kp2)))))))
+  (testing "Can generate the public-key from a secret-key"
+    (is (let [kp1 (generate-keypair)
+              kp2 (generate-keypair (:secret kp1))]
+          (array-eq (:public kp1)
+                    (:public kp2))))))
+
+;; These values taken from Kalium's test suite
 (def nonce
   (unhexify "69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37"))
 (def plaintext

--- a/test/caesium/crypto/box_test.clj
+++ b/test/caesium/crypto/box_test.clj
@@ -23,12 +23,12 @@
 (def ciphertext 
   (unhexify "f3ffc7703f9400e52a7dfb4b3d3305d98e993b9f48681273c29650ba32fc76ce48332ea7164d96a4476fb8c531a1186ac0dfc17c98dce87b4da7f011ec48c97271d2c20f9b928fe2270d6fb863d51738b48eeee314a7cc8ab932164548e526ae90224368517acfeabd6bb3732bc0e9da99832b61ca01b6de56244a9e88d5f9b37973f622a43d14a6599b1f654cb45a74e355a5"))
 
-(def bob-private-key 
+(def bob-secret-key 
   (unhexify "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"))
 (def bob-public-key 
   (unhexify "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"))
 
-(def alice-private-key 
+(def alice-secret-key 
   (unhexify "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"))
 (def alice-public-key 
   (unhexify "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"))
@@ -36,13 +36,13 @@
 (deftest box-encrypt-decrypt-test
   (testing "Bob can encrypt a message for Alice"
     (is (array-eq ciphertext
-                  (encrypt alice-public-key bob-private-key nonce plaintext))))
+                  (encrypt alice-public-key bob-secret-key nonce plaintext))))
   (testing "Alice can decrypt the message from Bob"
     (is (array-eq plaintext
-                  (decrypt bob-public-key alice-private-key nonce ciphertext))))
+                  (decrypt bob-public-key alice-secret-key nonce ciphertext))))
   (testing "No hex please"
     (is (thrown? java.lang.ClassCastException
                  (encrypt (hexify alice-public-key)
-                          (hexify bob-private-key)
+                          (hexify bob-secret-key)
                           nonce
                           plaintext)))))

--- a/test/caesium/crypto/generichash_test.clj
+++ b/test/caesium/crypto/generichash_test.clj
@@ -33,3 +33,21 @@
       (is (array-eq (apply blake2b args)
                     empty-string-digest)
           (str "args: " args)))))
+
+(def empty-string (.getBytes ""))
+
+(def sha256-message (.getBytes "My Bonnie lies over the ocean, my Bonnie lies over the sea"))
+(def sha256-digest (unhexify "d281d10296b7bde20df3f3f4a6d1bdb513f4aa4ccb0048c7b2f7f5786b4bcb77"))
+(def sha256-empty-string-digest (unhexify "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+(def sha512-message (.getBytes "My Bonnie lies over the ocean, Oh bring back my Bonnie to me"))
+(def sha512-digest (unhexify "2823e0373001b5f3aa6db57d07bc588324917fc221dd27975613942d7f2e19bf444654c8b9f4f9cb908ef15f2304522e60e9ced3fdec66e34bc2afb52be6ad1c"))
+(def sha512-empty-string-digest (unhexify "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"))
+
+(deftest sha-256-512-test
+  (testing "sha256 and 512 work directly"
+    (are [f message expected] (array-eq expected (f message))
+      sha256 sha256-message sha256-digest
+      sha256 empty-string sha256-empty-string-digest
+      sha512 sha512-message sha512-digest
+      sha512 empty-string sha512-empty-string-digest)))

--- a/test/caesium/crypto/sign_test.clj
+++ b/test/caesium/crypto/sign_test.clj
@@ -1,0 +1,41 @@
+(ns caesium.crypto.sign-test
+  (:require [caesium.crypto.sign :refer :all]
+            [caesium.util :refer :all]
+            [clojure.test :refer :all]))
+
+;; Test values taken from Kalium's suite
+(def secret
+  (unhexify "b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd"))
+(def message
+  (unhexify "916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40"))
+(def signature
+  (unhexify "6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509"))
+(def public
+  (unhexify "77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb"))
+
+(deftest generate-signing-keys-test
+  (testing "Simply generates new keypairs"
+    (is (let [kp1 (generate-signing-keys)
+              kp2 (generate-signing-keys)]
+          (and (not (array-eq (:public kp1) (:public kp2)))
+               (not (array-eq (:secret kp1) (:secret kp2)))))))
+  (testing "Can generate expected public-key from secret seed"
+    (is (array-eq public
+                  (:public (generate-signing-keys secret))))))
+
+(deftest sign-test
+  (testing "Can sign a message"
+    (is (array-eq signature
+                  (sign secret message)))))
+
+(deftest verify-test
+  (testing "Verifying correct signature works"
+    (is (verify public message signature))
+    (is (let [{pk :public ss :secret} (generate-signing-keys)]
+          (verify pk message
+                  (sign ss message)))))
+  (testing "Will not verify arbitrary signature"
+    (is (thrown-with-msg? java.lang.RuntimeException #"^signature was forged or corrupted$"
+                          (let [{pk :public ss :secret} (generate-signing-keys)
+                                other-sig (sign ss message)]
+                            (verify public message other-sig))))))

--- a/test/caesium/util_test.clj
+++ b/test/caesium/util_test.clj
@@ -21,3 +21,13 @@
          "02" [2]
          "ff" [-1]
          "010203" [1 2 3])))
+
+(deftest hexify-text
+  (testing "hexify works"
+    (are [hex raw] (= (hexify (byte-array raw))
+                      hex)
+         "" []
+         "01" [1]
+         "02" [2]
+         "ff" [-1]
+         "010203" [1 2 3])))


### PR DESCRIPTION
I've added a few more Kalium wrappers:

- box
- sign
- sha256 & sha512
- hexify

I've also updated to the latest stable version of Kalium and Clojure. Let me know if this is ok.