### PR TITLE
add wrappers for sealed boxes

### DIFF
--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -74,6 +74,7 @@
     [^long ^{size_t {}} crypto_box_secretkeybytes []]
     [^long ^{size_t {}} crypto_box_noncebytes []]
     [^long ^{size_t {}} crypto_box_macbytes []]
+    [^long ^{size_t {}} crypto_box_sealbytes []]
     [^String ^{size_t {}} crypto_box_primitive []]
 
     [^int crypto_box_seed_keypair
@@ -95,6 +96,18 @@
       ^bytes ^{Pinned {}} c
       ^long ^{LongLong {}} clen
       ^bytes ^{Pinned {}} n
+      ^bytes ^{Pinned {}} pk
+      ^bytes ^{Pinned {}} sk]]
+
+    [^int crypto_box_seal
+     [^bytes ^{Pinned {}} c
+      ^bytes ^{Pinned {}} m
+      ^long ^{LongLong {}} mlen
+      ^bytes ^{Pinned {}} pk]]
+    [^int crypto_box_seal_open
+     [^bytes ^{Pinned {}} m
+      ^bytes ^{Pinned {}} c
+      ^long ^{LongLong {}} clen
       ^bytes ^{Pinned {}} pk
       ^bytes ^{Pinned {}} sk]]
 

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -10,6 +10,7 @@
               secretkeybytes
               noncebytes
               macbytes
+              sealbytes
               primitive])
 
 (defn keypair-to-buf!
@@ -99,6 +100,33 @@
       m
       (throw (RuntimeException. "Ciphertext verification failed")))))
 
+(defn box-seal-to-buf!
+  "Encrypts ptext into out with `crypto_box_seal` using given public key.
+
+  All arguments must be `java.nio.ByteBuffer`.
+
+  This function is only useful if you're managing your own output
+  buffer, which includes in-place encryption. You probably
+  want [[box-seal]]."
+  [c m pk]
+  (b/✨ box-seal c m plen pk)
+  c)
+
+(defn box-seal-open-to-buf!
+  "Decrypts ptext into out with `crypto_box_seal_open` using given
+  public key and secret key.
+
+  All arguments must be `java.nio.ByteBuffer`.
+
+  This function is only useful if you're managing your own output
+  buffer, which includes in-place decryption. You probably
+  want [[box-seal-open]]."
+  [m c pk sk]
+  (let [res (b/✨ seal-open m c plen pk sk)]
+    (if (zero? res)
+      m
+      (throw (RuntimeException. "Ciphertext verification failed")))))
+
 (defn mlen->clen
   "Given a plaintext length, return the ciphertext length.
 
@@ -149,6 +177,36 @@
      (bb/->indirect-byte-buf sk))
     (bb/->bytes out)))
 
+(defn box-seal
+  "Encrypts ptext with `crypto_box_seal` using given public key.
+
+  This creates the output ciphertext byte array for you, which is
+  probably what you want. If you would like to manage the array
+  yourself, or do in-place encryption, see [[box-seal-to-buf!]]."
+  [ptext pk]
+  (let [out (bb/alloc (+ (bb/buflen ptext) sealbytes))]
+    (box-seal-to-buf!
+     out
+     (bb/->indirect-byte-buf ptext)
+     (bb/->indirect-byte-buf pk))
+    (bb/->bytes out)))
+
+(defn box-seal-open
+  "Decrypts ptext with `crypto_box_seal_open` using given public key, and
+  secret key.
+
+  This creates the output plaintext byte array for you, which is probably what
+  you want. If you would like to manage the array yourself, or do in-place
+  decryption, see [[box-seal-open-to-buf!]]."
+  [ctext pk sk]
+  (let [out (bb/alloc (- (bb/buflen ctext) sealbytes))]
+    (box-seal-open-to-buf!
+     out
+     (bb/->indirect-byte-buf ctext)
+     (bb/->indirect-byte-buf pk)
+     (bb/->indirect-byte-buf sk))
+    (bb/->bytes out)))
+
 (defn encrypt
   "Encrypt with `crypto_box_easy`.
 
@@ -172,3 +230,26 @@
   libsodium function."
   [pk sk nonce ctext]
   (box-open-easy ctext nonce pk sk))
+
+(defn anonymous-encrypt
+  "Encrypt with `crypto_box_seal`.
+
+  To encrypt, use the recipient's public key.
+
+  This is an alias for [[box-seal]] with a different argument
+  order. [[box-seal]] follows the same argument order as the libsodium
+  function."
+  [pk ptext]
+  (box-seal ptext pk))
+
+(defn anonymous-decrypt
+  "Decrypt with `crypto_box_seal_open`.
+
+  To decrypt, use the recipient's public key and recipient' secret
+  key.
+
+  This is an alias for [[box-seal-open]] with a different argument
+  order. [[box-seal-open]] follows the same argument order as the
+  libsodium function."
+  [pk sk ctext]
+  (box-seal-open ctext pk sk))

--- a/test/caesium/crypto/box_test.clj
+++ b/test/caesium/crypto/box_test.clj
@@ -50,3 +50,15 @@
       (is (thrown-with-msg?
            RuntimeException #"Ciphertext verification failed"
            (b/decrypt bob-pk alice-sk nonce forgery))))))
+
+(deftest anonymous-encrypt-decrypt-test
+  (let [ptext (box-vector "plaintext")
+        bob-pk (box-vector "bob-public-key")
+        bob-sk (box-vector "bob-secret-key")
+        ctext (b/anonymous-encrypt bob-pk ptext)]
+    (is (not (bb/bytes= ptext ctext)))
+    (is (bb/bytes= ptext (b/anonymous-decrypt bob-pk bob-sk ctext)))
+    (let [forgery (r/randombytes (alength ^bytes ctext))]
+      (is (thrown-with-msg?
+           RuntimeException #"Ciphertext verification failed"
+           (b/anonymous-decrypt bob-pk bob-sk forgery))))))


### PR DESCRIPTION
Add wrappers for the anonymous [encryption `libsodium` functions](https://download.libsodium.org/doc/public-key_cryptography/sealed_boxes.html).

Also, I was pretty unsure how to structure namespace or follow the function naming convention.  Let me know if you think we should create a new namespace or adopt a different function prefix.