### PR TITLE
libsodium crypto-pwhash functions implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ small wrappers around that, everything in it applies.
 
 [libsodiumdocs]: http://doc.libsodium.org
 
+### Password hashing
+
+Documentation coming soon.
+
 ## Differences with other bindings
 
 Instead of making specific claims about specific libraries which may become

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                                   [org.clojure/test.check "0.9.0"]
                                   [com.gfredericks/test.chuck "0.2.7"]
                                   [com.taoensso/timbre "4.7.3"]]}
-             :test {:plugins [[lein-cljfmt "0.3.0"]
+             :test {:plugins [[lein-cljfmt "0.5.7"]
                               [lein-kibit "0.1.2"]
                               [jonase/eastwood "0.2.3"]
                               [lein-codox "0.9.4"]

--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -189,6 +189,180 @@
       ^bytes ^{Pinned {}} salt
       ^bytes ^{Pinned {}} personal]]
 
+    [^int crypto_pwhash_alg_argon2i13 []]
+    [^int crypto_pwhash_alg_argon2id13 []]
+    [^int crypto_pwhash_alg_default []]
+    [^long ^{size_t {}} crypto_pwhash_bytes_min []]
+    [^long ^{size_t {}} crypto_pwhash_bytes_max []]
+    [^long ^{size_t {}} crypto_pwhash_passwd_min []]
+    [^long ^{size_t {}} crypto_pwhash_passwd_max []]
+    [^long ^{size_t {}} crypto_pwhash_saltbytes []]
+    [^long ^{size_t {}} crypto_pwhash_strbytes []]
+    [^String crypto_pwhash_strprefix []]
+    [^long ^{size_t {}} crypto_pwhash_opslimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_opslimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_memlimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_memlimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_opslimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_memlimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_opslimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_memlimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_opslimit_sensitive []]
+    [^long ^{size_t {}} crypto_pwhash_memlimit_sensitive []]
+    [^String crypto_pwhash_primitive []]
+    [^int crypto_pwhash
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} buflen
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^bytes ^{Pinned {}} salt
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit
+      ^long ^{LongLong {}} alg]]
+    [^int crypto_pwhash_str
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+    [^int crypto_pwhash_str_alg
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit
+      ^long ^{LongLong {}} alg]]
+    [^int crypto_pwhash_str_verify
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen]]
+    [^int crypto_pwhash_str_needs_rehash
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+
+    [^int crypto_pwhash_argon2i_alg_argon2i13 []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_bytes_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_bytes_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_passwd_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_passwd_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_saltbytes []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_strbytes []]
+    [^String crypto_pwhash_argon2i_strprefix []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_opslimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_opslimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_memlimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_memlimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_opslimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_memlimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_opslimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_memlimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_opslimit_sensitive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2i_memlimit_sensitive []]
+    [^int crypto_pwhash_argon2i
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} buflen
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^bytes ^{Pinned {}} salt
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit
+      ^long ^{LongLong {}} alg]]
+    [^int crypto_pwhash_argon2i_str
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+    [^int crypto_pwhash_argon2i_str_verify
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen]]
+    [^int crypto_pwhash_argon2i_str_needs_rehash
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+
+    [^int crypto_pwhash_argon2id_alg_argon2id13 []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_bytes_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_bytes_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_passwd_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_passwd_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_saltbytes []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_strbytes []]
+    [^String crypto_pwhash_argon2id_strprefix []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_opslimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_opslimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_memlimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_memlimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_opslimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_memlimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_opslimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_memlimit_moderate []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_opslimit_sensitive []]
+    [^long ^{size_t {}} crypto_pwhash_argon2id_memlimit_sensitive []]
+    [^int crypto_pwhash_argon2id
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} buflen
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^bytes ^{Pinned {}} salt
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit
+      ^long ^{LongLong {}} alg]]
+    [^int crypto_pwhash_argon2id_str
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+    [^int crypto_pwhash_argon2id_str_verify
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen]]
+    [^int crypto_pwhash_argon2id_str_needs_rehash
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_bytes_min []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_bytes_max []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_passwd_min []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_passwd_max []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_saltbytes []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_strbytes []]
+    [^String crypto_pwhash_scryptsalsa208sha256_strprefix []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_opslimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_opslimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_memlimit_min []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_memlimit_max []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_opslimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_memlimit_interactive []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive []]
+    [^long ^{size_t {}} crypto_pwhash_scryptsalsa208sha256_memlimit_sensitive []]
+    [^int crypto_pwhash_scryptsalsa208sha256
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} buflen
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^bytes ^{Pinned {}} salt
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+    [^int crypto_pwhash_scryptsalsa208sha256_str
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+    [^int crypto_pwhash_scryptsalsa208sha256_str_verify
+     [^bytes ^{Pinned {}} buf
+      ^bytes ^{Pinned {}} msg
+      ^long ^{LongLong {}} msglen]]
+    [^int crypto_pwhash_scryptsalsa208sha256_str_needs_rehash
+     [^bytes ^{Pinned {}} buf
+      ^long ^{LongLong {}} opslimit
+      ^long ^{LongLong {}} memlimit]]
+
     [^long ^{size_t {}} crypto_hash_sha256_bytes []]
     [^int crypto_hash_sha256
      [^bytes ^{Pinned {}} buf

--- a/src/caesium/crypto/pwhash.clj
+++ b/src/caesium/crypto/pwhash.clj
@@ -1,0 +1,261 @@
+(ns caesium.crypto.pwhash
+  (:refer-clojure :exclude [bytes hash])
+  (:require [caesium.binding :as b]
+            [caesium.byte-bufs :as bb]
+            [caesium.util :as u]
+            [medley.core :as m]))
+
+(b/defconsts [alg-argon2i13
+              alg-argon2id13
+              alg-default
+              bytes-min
+              bytes-max
+              passwd-min
+              passwd-max
+              saltbytes
+              strbytes
+              strprefix
+              opslimit-min
+              opslimit-max
+              memlimit-min
+              memlimit-max
+              opslimit-interactive
+              memlimit-interactive
+              opslimit-moderate
+              memlimit-moderate
+              opslimit-sensitive
+              memlimit-sensitive
+              primitive
+
+              argon2i-alg-argon2i13
+              argon2i-bytes-min
+              argon2i-bytes-max
+              argon2i-passwd-min
+              argon2i-passwd-max
+              argon2i-saltbytes
+              argon2i-strbytes
+              argon2i-strprefix
+              argon2i-opslimit-min
+              argon2i-opslimit-max
+              argon2i-memlimit-min
+              argon2i-memlimit-max
+              argon2i-opslimit-interactive
+              argon2i-memlimit-interactive
+              argon2i-opslimit-moderate
+              argon2i-memlimit-moderate
+              argon2i-opslimit-sensitive
+              argon2i-memlimit-sensitive
+
+              argon2id-alg-argon2id13
+              argon2id-bytes-min
+              argon2id-bytes-max
+              argon2id-passwd-min
+              argon2id-passwd-max
+              argon2id-saltbytes
+              argon2id-strbytes
+              argon2id-strprefix
+              argon2id-opslimit-min
+              argon2id-opslimit-max
+              argon2id-memlimit-min
+              argon2id-memlimit-max
+              argon2id-opslimit-interactive
+              argon2id-memlimit-interactive
+              argon2id-opslimit-moderate
+              argon2id-memlimit-moderate
+              argon2id-opslimit-sensitive
+              argon2id-memlimit-sensitive
+
+              scryptsalsa208sha256-bytes-min
+              scryptsalsa208sha256-bytes-max
+              scryptsalsa208sha256-passwd-min
+              scryptsalsa208sha256-passwd-max
+              scryptsalsa208sha256-saltbytes
+              scryptsalsa208sha256-strbytes
+              scryptsalsa208sha256-strprefix
+              scryptsalsa208sha256-opslimit-min
+              scryptsalsa208sha256-opslimit-max
+              scryptsalsa208sha256-memlimit-min
+              scryptsalsa208sha256-memlimit-max
+              scryptsalsa208sha256-opslimit-interactive
+              scryptsalsa208sha256-memlimit-interactive
+              scryptsalsa208sha256-opslimit-sensitive
+              scryptsalsa208sha256-memlimit-sensitive])
+
+(defn pwhash-to-buf!
+  [buf msg salt opslimit memlimit alg]
+  (b/✨ pwhash buf msg salt opslimit memlimit alg)
+  buf)
+
+(defn pwhash
+  "hashes a given password using default method"
+  [key-size msg salt opslimit memlimit alg]
+  (let [buf (bb/alloc key-size)]
+    (pwhash-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     (bb/->indirect-byte-buf salt)
+     opslimit memlimit alg)
+    (bb/->bytes buf)))
+
+(defn pwhash-str-to-buf!
+  [buf msg opslimit memlimit]
+  (b/✨ pwhash-str buf msg opslimit memlimit)
+  buf)
+
+(defn pwhash-str
+  "returns a string hash complete with all information required to verify"
+  [msg opslimit memlimit]
+  (let [buf (bb/alloc strbytes)]
+    (pwhash-str-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     opslimit memlimit)
+    (String. (bb/->bytes buf))))
+
+(defn pwhash-str-alg-to-buf!
+  [buf msg opslimit memlimit alg]
+  (b/✨ pwhash-str-alg buf msg opslimit memlimit alg)
+  buf)
+
+(defn pwhash-str-alg
+  [msg opslimit memlimit alg]
+  (let [buf (bb/alloc strbytes)]
+    (pwhash-str-alg-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     opslimit memlimit alg)
+    (String. (bb/->bytes buf))))
+
+(defn pwhash-str-verify
+  [hashpass passwd]
+  (let [buf (bb/->indirect-byte-buf hashpass)
+        msg (bb/->indirect-byte-buf passwd)]
+    (b/✨ pwhash-str-verify buf msg)))
+
+(defn str-needs-rehash
+  [hashpass opslimit memlimit]
+  (let [buf (bb/->indirect-byte-buf hashpass)]
+    (b/✨  str-needs-rehash buf opslimit memlimit)))
+
+(defn pwhash-argon2i-to-buf!
+  [buf msg salt opslimit memlimit alg]
+  (b/✨ pwhash-argon2i buf msg salt opslimit memlimit alg)
+  buf)
+
+(defn argon2i-str-to-buf!
+  [buf msg opslimit memlimit]
+  (b/✨ pwhash-argon2i-str buf msg opslimit memlimit)
+  buf)
+
+(defn argon2i
+  "hashes a given password using argon2i"
+  [key-size msg salt opslimit memlimit alg]
+  (let [buf (bb/alloc key-size)]
+    (pwhash-argon2i-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     (bb/->indirect-byte-buf salt)
+     opslimit memlimit alg)
+    (bb/->bytes buf)))
+
+(defn argon2i-str
+  [msg opslimit memlimit]
+  (let [buf (bb/alloc strbytes)]
+    (argon2i-str-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     opslimit memlimit)
+    (String. (bb/->bytes buf))))
+
+(defn argon2i-str-verify
+  [hashpass passwd]
+  (let [buf (bb/->indirect-byte-buf hashpass)
+        msg (bb/->indirect-byte-buf passwd)]
+    (b/✨ argon2i-str-verify buf msg)))
+
+(defn argon2i-str-needs-rehash
+  [hashpass opslimit memlimit]
+  (let [buf (bb/->indirect-byte-buf hashpass)]
+    (b/✨  argon2i-str-needs-rehash buf opslimit memlimit)))
+
+(defn argon2id-to-buf!
+  [buf msg salt opslimit memlimit alg]
+  (b/✨ pwhash-argon2id buf msg salt opslimit memlimit alg)
+  buf)
+
+(defn argon2id
+  "hashes a given password using argon2id"
+  [key-size msg salt opslimit memlimit alg]
+  (let [buf (bb/alloc key-size)]
+    (argon2id-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     (bb/->indirect-byte-buf salt)
+     opslimit memlimit alg)
+    (bb/->bytes buf)))
+
+(defn argon2id-str-to-buf!
+  [buf msg opslimit memlimit]
+  (b/✨ pwhash-argon2id-str buf msg opslimit memlimit)
+  buf)
+
+(defn argon2id-str
+  [msg opslimit memlimit]
+  (let [buf (bb/alloc strbytes)]
+    (argon2id-str-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     opslimit memlimit)
+    (String. (bb/->bytes buf))))
+
+(defn argon2id-str-verify
+  [hashpass passwd]
+  (let [buf (bb/->indirect-byte-buf hashpass)
+        msg (bb/->indirect-byte-buf passwd)]
+    (b/✨ argon2id-str-verify buf msg)))
+
+(defn argon2id-str-needs-rehash
+  [hashpass opslimit memlimit]
+  (let [buf (bb/->indirect-byte-buf hashpass)]
+    (b/✨  argon2id-str-needs-rehash buf opslimit memlimit)))
+
+(defn scryptsalsa208sha256-to-buf!
+  [buf msg salt opslimit memlimit]
+  (b/✨ pwhash-scryptsalsa208sha256 buf msg salt opslimit memlimit)
+  buf)
+
+(defn scryptsalsa208sha256
+  "hashes a given password using scryptsalsa208sha256"
+  [key-size msg salt opslimit memlimit]
+  (let [buf (bb/alloc key-size)]
+    (scryptsalsa208sha256-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     (bb/->indirect-byte-buf salt)
+     opslimit memlimit)
+    (bb/->bytes buf)))
+
+(defn scryptsalsa208sha256-str-to-buf!
+  [buf msg opslimit memlimit]
+  (b/✨ pwhash-scryptsalsa208sha256-str buf msg opslimit memlimit)
+  buf)
+
+(defn scryptsalsa208sha256-str
+  [msg opslimit memlimit]
+  (let [buf (bb/alloc strbytes)]
+    (scryptsalsa208sha256-str-to-buf!
+     buf
+     (bb/->indirect-byte-buf msg)
+     opslimit memlimit)
+    (String. (bb/->bytes buf))))
+
+(defn scryptsalsa208sha256-str-verify
+  [hashpass passwd]
+  (let [buf (bb/->indirect-byte-buf hashpass)
+        msg (bb/->indirect-byte-buf passwd)]
+    (b/✨ scryptsalsa208sha256-str-verify buf msg)))
+
+(defn scryptsalsa208sha256-str-needs-rehash
+  [hashpass opslimit memlimit]
+  (let [buf (bb/->indirect-byte-buf hashpass)]
+    (b/✨  scryptsalsa208sha256-str-needs-rehash buf opslimit memlimit)))

--- a/test/caesium/binding_test.clj
+++ b/test/caesium/binding_test.clj
@@ -80,12 +80,20 @@
              LongLongByReference #{})
            annotations))))
 
+(defn int-func?
+  "checks if given fn is supposed to have an int return type"
+  [f]
+  (let [fns  #{"sodium_init" "crypto_pwhash_argon2i_alg_argon2i13"
+               "crypto_pwhash_alg_default" "crypto_pwhash_alg_argon2i13"
+               "crypto_pwhash_alg_argon2id13" "crypto_pwhash_argon2id_alg_argon2id13"}]
+    (contains? fns f)))
+
 (defn check-const-method
   "Check a method binding a const fn."
   [^Method method]
   (let [rtype (.getGenericReturnType method)]
     (condp = rtype
-      Integer/TYPE (is (= "sodium_init" (.getName method)))
+      Integer/TYPE (is (int-func? (.getName method)))
       Long/TYPE (is (= #{size_t} (clean-annotations (.getAnnotations method))))
       (is (= String rtype)))))
 

--- a/test/caesium/crypto/pwhash_test.clj
+++ b/test/caesium/crypto/pwhash_test.clj
@@ -1,0 +1,174 @@
+(ns caesium.crypto.pwhash-test
+  (:require [caesium.crypto.pwhash :as p]
+            [caesium.byte-bufs :as bb]
+            [caesium.test-utils :refer [const-test]]
+            [caesium.vectors :as v]
+            [caesium.util :as u]
+            [caesium.randombytes :as r]
+            [clojure.test :refer [are deftest is]]))
+
+(const-test
+ p/alg-argon2i13 1
+ p/alg-default 2
+ p/bytes-min 16
+ p/bytes-max 4294967295
+ p/passwd-min 0
+ p/passwd-max 4294967295
+ p/saltbytes 16
+ p/strbytes 128
+ p/strprefix "$argon2id$"
+ p/opslimit-min 1
+ p/opslimit-max 4294967295
+ p/memlimit-min 8192
+ p/opslimit-interactive 2
+ p/memlimit-interactive  67108864
+ p/opslimit-moderate 3
+ p/memlimit-moderate 268435456
+ p/opslimit-sensitive 4
+ p/memlimit-sensitive 1073741824
+ p/primitive "argon2i"
+
+ p/argon2i-alg-argon2i13 1
+ p/argon2i-bytes-min 16
+ p/argon2i-bytes-max 4294967295
+ p/argon2i-passwd-min 0
+ p/argon2i-passwd-max 4294967295
+ p/argon2i-saltbytes 16
+ p/argon2i-strbytes 128
+ p/argon2i-strprefix "$argon2i$"
+ p/argon2i-opslimit-min 3
+ p/argon2i-opslimit-max 4294967295
+ p/argon2i-memlimit-min 8192
+ p/argon2i-opslimit-interactive 4
+ p/argon2i-memlimit-interactive  33554432
+ p/argon2i-opslimit-moderate 6
+ p/argon2i-memlimit-moderate 134217728
+ p/argon2i-opslimit-sensitive 8
+ p/argon2i-memlimit-sensitive 536870912
+
+ p/argon2id-alg-argon2id13 2
+ p/argon2id-bytes-min 16
+ p/argon2id-bytes-max 4294967295
+ p/argon2id-passwd-min 0
+ p/argon2id-passwd-max 4294967295
+ p/argon2id-saltbytes 16
+ p/argon2id-strbytes 128
+ p/argon2id-strprefix "$argon2id$"
+ p/argon2id-opslimit-min 1
+ p/argon2id-opslimit-max 4294967295
+ p/argon2id-memlimit-min 8192
+ p/argon2id-opslimit-interactive 2
+ p/argon2id-memlimit-interactive  67108864
+ p/argon2id-opslimit-moderate 3
+ p/argon2id-memlimit-moderate 268435456
+ p/argon2id-opslimit-sensitive 4
+ p/argon2id-memlimit-sensitive 1073741824
+
+ p/scryptsalsa208sha256-bytes-min 16
+ p/scryptsalsa208sha256-bytes-max 0x1fffffffe0
+ p/scryptsalsa208sha256-passwd-min 0
+ p/scryptsalsa208sha256-saltbytes 32
+ p/scryptsalsa208sha256-strbytes 102
+ p/scryptsalsa208sha256-strprefix "$7$"
+ p/scryptsalsa208sha256-opslimit-min 32768
+ p/scryptsalsa208sha256-opslimit-max 4294967295
+ p/scryptsalsa208sha256-memlimit-min 16777216
+ p/scryptsalsa208sha256-opslimit-interactive 524288
+ p/scryptsalsa208sha256-memlimit-interactive  16777216
+ p/scryptsalsa208sha256-opslimit-sensitive 33554432
+ p/scryptsalsa208sha256-memlimit-sensitive  1073741824)
+
+;;the salt is random
+;;the (hex) key value is the output of hashing "password" using libsodium (c version)
+(deftest pwhash-alg-default-test
+  (let [salt (u/unhexify "7cb3b8ceb58e7847fc4485e63dbfdb9b")]
+    (is (= "86b902e6577791ff5e1aaa73a57d21ee7a8822ed8e183940af4fa1ba6ab9803c" (u/hexify (p/pwhash 32 "password" salt p/opslimit-min p/memlimit-min p/alg-default))))))
+
+;;the salt is random
+;;the (hex) key value is the output of hashing "password" using libsodium (c version)
+(deftest pwhash-alg-argon2i-test
+  (let [salt (u/unhexify "7cb3b8ceb58e7847fc4485e63dbfdb9b")]
+    (is (= "75a10fdb4db0836498f824f1f0cc9ab9d3bb194d41b8dd66bd1ca6f0cf686810" (u/hexify (p/pwhash 32 "password" salt p/argon2i-opslimit-min p/argon2i-memlimit-interactive p/alg-argon2i13))))))
+
+(deftest pwhash-str-and-verify-test-equal
+  (let [hashpass (p/pwhash-str "password" p/opslimit-min p/memlimit-interactive)
+        result (p/pwhash-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest pwhash-str-and-verify-test-unequal
+  (let [hashpass (p/pwhash-str "password1" p/opslimit-min p/memlimit-interactive)
+        result (p/pwhash-str-verify hashpass "password")]
+    (is (not (= result 0)))))
+
+(deftest pwhash-str-alg-and-verify-test-equal
+  (let [hashpass (p/pwhash-str-alg "password" p/opslimit-min p/memlimit-min p/alg-default)
+        result (p/pwhash-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest pwhash-str-alg-argon2i13-and-verify-test-equal
+  (let [hashpass (p/pwhash-str-alg "password" p/argon2i-opslimit-min p/argon2i-memlimit-min p/alg-argon2i13)
+        result (p/pwhash-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest str-needs-rehash-test
+  (let [hashpass (p/pwhash-str-alg "password" p/argon2i-opslimit-min p/argon2i-memlimit-min p/alg-argon2i13)
+        result (p/str-needs-rehash hashpass p/argon2i-opslimit-interactive p/argon2i-memlimit-interactive)]
+    (is (= result 1))))
+
+;;the salt is random
+;;the (hex) key value is the output of hashing "password" using libsodium (c version) using argon2i
+(deftest pwhash-argon2i-alg-argon2i13-test
+  (let [salt (u/unhexify "7cb3b8ceb58e7847fc4485e63dbfdb9b")]
+    (is (= "75a10fdb4db0836498f824f1f0cc9ab9d3bb194d41b8dd66bd1ca6f0cf686810" (u/hexify (p/argon2i 32 "password" salt p/argon2i-opslimit-min p/argon2i-memlimit-interactive p/argon2i-alg-argon2i13))))))
+
+(deftest argon2i-str-and-verify-test-equal
+  (let [hashpass (p/argon2i-str "password" p/argon2i-opslimit-min p/argon2i-memlimit-interactive)
+        result (p/argon2i-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest argon2i-str-and-verify-test-unequal
+  (let [hashpass (p/argon2i-str "password1" p/argon2i-opslimit-min p/argon2i-memlimit-interactive)
+        result (p/argon2i-str-verify hashpass "password")]
+    (is (not (= result 0)))))
+
+(deftest argon2i-str-needs-rehash-test
+  (let [hashpass (p/pwhash-str-alg "password" p/argon2i-opslimit-min p/argon2i-memlimit-min p/alg-argon2i13)
+        result (p/argon2i-str-needs-rehash hashpass p/argon2i-opslimit-interactive p/argon2i-memlimit-interactive)]
+    (is (= result 1))))
+
+;;the salt is random
+;;the (hex) key value is the output of hashing "password" using libsodium (c version) using argon2id
+(deftest pwhash-argon2id-alg-argon2id13-test
+  (let [salt (u/unhexify "7cb3b8ceb58e7847fc4485e63dbfdb9b")]
+    (is (= "86b902e6577791ff5e1aaa73a57d21ee7a8822ed8e183940af4fa1ba6ab9803c" (u/hexify (p/argon2id 32 "password" salt p/argon2id-opslimit-min p/argon2id-memlimit-min p/argon2id-alg-argon2id13))))))
+
+(deftest argon2id-str-and-verify-test-equal
+  (let [hashpass (p/argon2id-str "password" p/opslimit-min p/argon2id-memlimit-min)
+        result (p/argon2id-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest argon2id-str-needs-rehash-test
+  (let [hashpass (p/pwhash-str-alg "password" p/argon2id-opslimit-min p/argon2id-memlimit-min p/alg-argon2id13)
+        result (p/argon2id-str-needs-rehash hashpass p/argon2id-opslimit-interactive p/argon2id-memlimit-interactive)]
+    (is (= result 1))))
+
+;;the salt is random
+;;the (hex) key value is the output of hashing "password" using libsodium (c version) using scryptsalsa208sha256
+(deftest pwhash-scryptsalsa208sha256-test
+  (let [salt (u/unhexify "7cb3b8ceb58e7847fc4485e63dbfdb9b7cb3b8ceb58e7847fc4485e63dbfdb9b")]
+    (is (= "8f9a89dc959a951bf15b6cc29461f251973c6ea9df6880875423f2e15d0d3595" (u/hexify (p/scryptsalsa208sha256 32 "password" salt p/scryptsalsa208sha256-opslimit-min p/scryptsalsa208sha256-memlimit-interactive))))))
+
+(deftest scryptsalsa208sha256-str-and-verify-test-equal
+  (let [hashpass (p/scryptsalsa208sha256-str "password" p/scryptsalsa208sha256-opslimit-min p/scryptsalsa208sha256-memlimit-interactive)
+        result (p/scryptsalsa208sha256-str-verify hashpass "password")]
+    (is (= result 0))))
+
+(deftest scryptsalsa208sha256-str-and-verify-test-unequal
+  (let [hashpass (p/scryptsalsa208sha256-str "password" p/scryptsalsa208sha256-opslimit-min p/scryptsalsa208sha256-memlimit-interactive)
+        result (p/scryptsalsa208sha256-str-verify hashpass "password1")]
+    (is (not (= result 0)))))
+
+(deftest scryptsalsa208sha256-str-needs-rehash-test
+  (let [hashpass (p/scryptsalsa208sha256-str "password" p/scryptsalsa208sha256-opslimit-min p/scryptsalsa208sha256-memlimit-min)
+        result (p/scryptsalsa208sha256-str-needs-rehash hashpass p/scryptsalsa208sha256-opslimit-interactive p/scryptsalsa208sha256-memlimit-interactive)]
+    (is (= result 1))))


### PR DESCRIPTION
My second iteration at this. All the functions are implemented. However, the argon2id functions only return zeros instead of the actual hashing. Not sure what is going on. 
Default (which uses argon2i), argon2i and scrypt functions seem to be working fine.  I do have two tests that are failing that are related to argon2id. Not sure if I should remove them for CI/CD stuff to work.