### PR TITLE
AWS Lambda Compatibility

### DIFF
--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -278,7 +278,7 @@
               ~docstring
               (~(java-call-sym c-name) sodium)))))
 
-(defmacro ✨
+(defmacro magic-sparkles
   "Produces a form for calling named fn with lots of magic:
 
   * The fn-name is specified using its short name, which is resolved

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -20,9 +20,9 @@
   This API matches libsodium's `crypto_box_keypair` and
   `crpyto_box_seed_keypair`."
   ([pk sk]
-   (b/✨ keypair pk sk))
+   (b/magic-sparkles keypair pk sk))
   ([pk sk seed]
-   (b/✨ seed-keypair pk sk seed)))
+   (b/magic-sparkles seed-keypair pk sk seed)))
 
 (defn keypair!
   "Create a `crypto_box` keypair.
@@ -82,7 +82,7 @@
   buffer, which includes in-place encryption. You probably
   want [[box-easy]]."
   [c m n pk sk]
-  (b/✨ easy c m plen n pk sk)
+  (b/magic-sparkles easy c m plen n pk sk)
   c)
 
 (defn box-open-easy-to-buf!
@@ -95,7 +95,7 @@
   buffer, which includes in-place decryption. You probably
   want [[box-open-easy]]."
   [m c n pk sk]
-  (let [res (b/✨ open-easy m c n pk sk)]
+  (let [res (b/magic-sparkles open-easy m c n pk sk)]
     (if (zero? res)
       m
       (throw (RuntimeException. "Ciphertext verification failed")))))
@@ -109,7 +109,7 @@
   buffer, which includes in-place encryption. You probably
   want [[box-seal]]."
   [c m pk]
-  (b/✨ box-seal c m plen pk)
+  (b/magic-sparkles box-seal c m plen pk)
   c)
 
 (defn box-seal-open-to-buf!
@@ -122,7 +122,7 @@
   buffer, which includes in-place decryption. You probably
   want [[box-seal-open]]."
   [m c pk sk]
-  (let [res (b/✨ seal-open m c plen pk sk)]
+  (let [res (b/magic-sparkles seal-open m c plen pk sk)]
     (if (zero? res)
       m
       (throw (RuntimeException. "Ciphertext verification failed")))))

--- a/src/caesium/crypto/generichash.clj
+++ b/src/caesium/crypto/generichash.clj
@@ -30,7 +30,7 @@
   ([buf msg]
    (hash-to-buf! buf msg {}))
   ([buf msg {:keys [key] :or {key (bb/alloc 0)}}]
-   (b/✨ generichash buf msg key)
+   (b/magic-sparkles generichash buf msg key)
    buf))
 
 (defn hash
@@ -66,8 +66,8 @@
      ;; wasn't passed and an empty salt, to call a different fn.
      (let [salt (or salt (bb/alloc blake2b-saltbytes))
            personal (or personal (bb/alloc blake2b-personalbytes))]
-       (b/✨ blake2b-salt-personal buf msg key salt personal))
-     (b/✨ blake2b buf msg key))
+       (b/magic-sparkles blake2b-salt-personal buf msg key salt personal))
+     (b/magic-sparkles blake2b buf msg key))
    buf))
 
 (defn blake2b

--- a/src/caesium/crypto/hash.clj
+++ b/src/caesium/crypto/hash.clj
@@ -11,7 +11,7 @@
   You only want this to manage the output byte array yourself. Otherwise, you
   want [[sha256]]."
   [buf msg]
-  (b/✨ sha256 buf msg))
+  (b/magic-sparkles sha256 buf msg))
 
 (defn sha256
   "Computes the SHA-256 hash of message in the given byte array.
@@ -30,7 +30,7 @@
   You only want this to manage the output byte array yourself. Otherwise, you
   want [[sha512]]."
   [buf msg]
-  (b/✨ sha512 buf msg))
+  (b/magic-sparkles sha512 buf msg))
 
 (defn sha512
   "Computes the SHA-512 hash of message in the given byte array.

--- a/src/caesium/crypto/scalarmult.clj
+++ b/src/caesium/crypto/scalarmult.clj
@@ -15,9 +15,9 @@
   buffer. If no point is specified, the standard base point of the
   curve is used."
   ([q n]
-   (b/✨ scalarmult-base q n))
+   (b/magic-sparkles scalarmult-base q n))
   ([q n p]
-   (b/✨ scalarmult q n p)))
+   (b/magic-sparkles scalarmult q n p)))
 
 (defn scalarmult
   "Computes the scalar multiplication of a point. If no point is

--- a/src/caesium/crypto/secretbox.clj
+++ b/src/caesium/crypto/secretbox.clj
@@ -16,7 +16,7 @@
   You only want this to manage the output byte buffer yourself. Otherwise,
   you want [[secretbox-easy]]."
   [c m n k]
-  (b/✨ easy c m n k))
+  (b/magic-sparkles easy c m n k))
 
 (defn secretbox-easy
   "Encrypt with `crypto_secretbox_easy`.
@@ -46,7 +46,7 @@
   You only want this to manage the output byte array yourself. Otherwise,
   you want [[secretbox-open-easy]]."
   [m c n k]
-  (let [res (b/✨ open-easy m c n k)]
+  (let [res (b/magic-sparkles open-easy m c n k)]
     (if (zero? res)
       m
       (throw (RuntimeException. "Ciphertext verification failed")))))

--- a/src/caesium/crypto/sign.clj
+++ b/src/caesium/crypto/sign.clj
@@ -14,13 +14,13 @@
   ([]
    (let [pk (bb/alloc publickeybytes)
          sk (bb/alloc secretkeybytes)]
-     (b/✨ sign-keypair pk sk)
+     (b/magic-sparkles sign-keypair pk sk)
      {:public pk :secret sk}))
   ([seed]
    (let [pk (bb/alloc publickeybytes)
          sk (bb/alloc secretkeybytes)
          seed (bb/->indirect-byte-buf seed)]
-     (b/✨ sign-seed-keypair pk sk seed)
+     (b/magic-sparkles sign-seed-keypair pk sk seed)
      {:public pk :secret sk})))
 
 (def ^:deprecated generate-signing-keys
@@ -31,7 +31,7 @@
   "Puts a signed version of the given message using given secret key into the
   given out buffer."
   [sm m sk]
-  (b/✨ sign sm m sk)
+  (b/magic-sparkles sign sm m sk)
   sm)
 
 (defn signed
@@ -48,7 +48,7 @@
   "Puts a signature of the given message using given secret key into the given
   out buffer."
   [sig m sk]
-  (b/✨ sign-detached sig m sk)
+  (b/magic-sparkles sign-detached sig m sk)
   sig)
 
 (defn sign
@@ -71,7 +71,7 @@
    (let [m (bb/alloc (- (bb/buflen sm) bytes))
          sm (bb/->indirect-byte-buf sm)
          pk (bb/->indirect-byte-buf pk)
-         res (b/✨ sign-open m sm pk)]
+         res (b/magic-sparkles sign-open m sm pk)]
      (if (zero? res)
        (bb/->bytes m)
        (throw (RuntimeException. "Signature validation failed")))))
@@ -79,6 +79,6 @@
    (let [sig (bb/->indirect-byte-buf sig)
          m (bb/->indirect-byte-buf m)
          pk (bb/->indirect-byte-buf pk)
-         res (b/✨ sign-verify-detached sig m pk)]
+         res (b/magic-sparkles sign-verify-detached sig m pk)]
      (when-not (zero? res)
        (throw (RuntimeException. "Signature validation failed"))))))

--- a/test/caesium/binding_test.clj
+++ b/test/caesium/binding_test.clj
@@ -110,18 +110,18 @@
            (and (is (= expected-form expanded))
                 (is (= expected-metas (map meta args))))))
     'caesium.crypto.box
-    '(caesium.binding/✨ keypair sk pk)
+    '(caesium.binding/magic-sparkles keypair sk pk)
     `(.crypto_box_keypair b/sodium ~'pk ~'sk)
     [buf-tag buf-tag]
 
     'caesium.crypto.box
-    '(caesium.binding/✨ open-easy m c n pk sk)
+    '(caesium.binding/magic-sparkles open-easy m c n pk sk)
     `(.crypto_box_open_easy
       b/sodium ~'m ~'c (long (bb/buflen ~'c)) ~'n ~'pk ~'sk)
     [buf-tag buf-tag nil buf-tag buf-tag buf-tag]
 
     'caesium.crypto.generichash
-    '(caesium.binding/✨ generichash buf msg key)
+    '(caesium.binding/magic-sparkles generichash buf msg key)
     `(.crypto_generichash
       b/sodium
       ~'buf (long (bb/buflen ~'buf))
@@ -130,17 +130,17 @@
     [buf-tag nil buf-tag nil buf-tag nil]
 
     'caesium.crypto.scalarmult
-    '(caesium.binding/✨ scalarmult q n p)
+    '(caesium.binding/magic-sparkles scalarmult q n p)
     `(.crypto_scalarmult b/sodium ~'q ~'n ~'p)
     [buf-tag buf-tag buf-tag]
 
     'caesium.crypto.scalarmult
-    '(caesium.binding/✨ scalarmult-base q n)
+    '(caesium.binding/magic-sparkles scalarmult-base q n)
     `(.crypto_scalarmult_base b/sodium ~'q ~'n)
     [buf-tag buf-tag]
 
     'caesium.crypto.sign
-    '(caesium.binding/✨ sign-open m sm pk)
+    '(caesium.binding/magic-sparkles sign-open m sm pk)
     `(.crypto_sign_open
       b/sodium
       ~'m nil


### PR DESCRIPTION
When attempting to use caesium in AWS Lambda, this error occurs:

```
{
      "errorMessage": "Error loading class app.handler:
    caesium/binding$✨",
      "errorType": "java.lang.NoClassDefFoundError"
}
```

There appears to be an issue in Lambda with executing Clojure code that
contains Unicode characters. This error does not occur in an EC2
instance using the same AMI that Lambda uses.

So while it is not wrong that caesium had named this macro as a Unicode
character, and this is surely Lambda's bug that they should fix, in the
interim this changes caesium to use a name that is exactly as
descriptive (✨ vs `magic-sparkles`), but is capable of being executed by
AWS Lambda.

I chose the name `magic-sparkles` because the test was already called
`magic-sparkles-test`, which indicated that this was how the Unicode
character was pronounced.