### PR TITLE
Add lein-ancient to the test profile for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - wget https://github.com/lvh/libsodium-debs/raw/master/libsodium-1.0.15_amd64.deb
   - sudo dpkg -i libsodium-1.0.15_amd64.deb
 script:
+  - lein with-profile +test ancient
   - lein with-profile +test cljfmt check
   - lein with-profile +test kibit
   - lein with-profile +test eastwood || true

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
              :dev {:dependencies [[criterium "0.4.4"]
                                   [org.clojure/test.check "0.9.0"]
                                   [com.gfredericks/test.chuck "0.2.8"]]}
-             :test {:plugins [[lein-cljfmt "0.5.7"]
+             :test {:plugins [[lein-ancient "0.6.15"]
+                              [lein-cljfmt "0.5.7"]
                               [lein-kibit "0.1.2"]
                               [jonase/eastwood "0.2.3"]
                               [lein-codox "0.9.4"]


### PR DESCRIPTION
The patch will show what are the outdated dependencies before running any
linting/testing. It does not fail the build.