### PR TITLE
Use build matrix on travis-ci with different libsodium versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: clojure
 lein: lein2
 dist: trusty
-matrix:
-  include:
-  - name: "libsodium 1.0.15"
-    env: LIBSODIUM_VERSION=1.0.15
-  - name: "libsodium 1.0.13"
-    env: LIBSODIUM_VERSION=1.0.13
 jdk:
   - oraclejdk8
 cache:
   directories:
     - $HOME/.lein
     - $HOME/.m2
+env:
+  - LIBSODIUM_VERSION=1.0.15
+  - LIBSODIUM_VERSION=1.0.13
 install:
   - wget https://github.com/lvh/libsodium-debs/raw/master/libsodium-${LIBSODIUM_VERSION}_amd64.deb
   - sudo dpkg -i libsodium-${LIBSODIUM_VERSION}_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ cache:
 env:
   - LIBSODIUM_VERSION=1.0.15
   - LIBSODIUM_VERSION=1.0.13
+matrix:
+  allow_failures:
+    - env: LIBSODIUM_VERSION=1.0.13
+  fast_finish: true
 install:
   - wget https://github.com/lvh/libsodium-debs/raw/master/libsodium-${LIBSODIUM_VERSION}_amd64.deb
   - sudo dpkg -i libsodium-${LIBSODIUM_VERSION}_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ cache:
     - $HOME/.lein
     - $HOME/.m2
 env:
+  - LIBSODIUM_VERSION=1.0.16
   - LIBSODIUM_VERSION=1.0.15
+  - LIBSODIUM_VERSION=1.0.14
   - LIBSODIUM_VERSION=1.0.13
 matrix:
   allow_failures:
+    - env: LIBSODIUM_VERSION=1.0.14
     - env: LIBSODIUM_VERSION=1.0.13
   fast_finish: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: clojure
 lein: lein2
 dist: trusty
+matrix:
+  include:
+  - name: "libsodium 1.0.15"
+    env: LIBSODIUM_VERSION=1.0.15
+  - name: "libsodium 1.0.13"
+    env: LIBSODIUM_VERSION=1.0.13
 jdk:
   - oraclejdk8
 cache:
@@ -8,8 +14,8 @@ cache:
     - $HOME/.lein
     - $HOME/.m2
 install:
-  - wget https://github.com/lvh/libsodium-debs/raw/master/libsodium-1.0.15_amd64.deb
-  - sudo dpkg -i libsodium-1.0.15_amd64.deb
+  - wget https://github.com/lvh/libsodium-debs/raw/master/libsodium-${LIBSODIUM_VERSION}_amd64.deb
+  - sudo dpkg -i libsodium-${LIBSODIUM_VERSION}_amd64.deb
 script:
   - lein with-profile +test cljfmt check
   - lein with-profile +test kibit


### PR DESCRIPTION
More debs are needed in lvh/libsodium-debs in order to test other versions. Opening the PR to see if there are no mistakes in the travis.-ci configuration.