### PR TITLE
Added note on installing libsodium before trying to use caesium

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ a more convenient fork of the original [NaCl][nacl] library by
 [djb]: http://cr.yp.to/djb.html
 [libsodium]: https://github.com/jedisct1/libsodium
 
+***NOTE:*** Install [libsodium](https://libsodium.gitbook.io/doc/installation) before trying to use caesium. Otherwise you will get an error saying the "code size is too large" or something along those lines.
+
 ## Minimum viable snippet
 
 Here's a sample of how you can use secretbox:


### PR DESCRIPTION
As mentioned in #55, the error that results from not having libsodium installed is very confusing. This does not fix the error message emitted by not having it installed, but it adds a note to the README stating that that error occurs if libsodium is not installed.