### PR TITLE
Fix the "Unmatched delimiter: ]" error

### DIFF
--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -632,7 +632,7 @@
       ^long ^{LongLong {}} subklen
       ^long ^{LongLong {}} subkid
       ^bytes ^{Pinned {}} ctx
-      ^bytes ^{Pinned {}} k]]]
+      ^bytes ^{Pinned {}} k]]
 
     [^long ^{size_t {}} crypto_core_ristretto255_bytes []]
     [^long ^{size_t {}} crypto_core_ristretto255_hashbytes []]


### PR DESCRIPTION
Merging of the previous two PRs led to an additional `]` being brought where it didn't belong. This fixes it.