### PR TITLE
Lint the code with clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,6 @@
-{:lint-as {caesium.binding/defconsts clojure.core/declare}
+{:lint-as {caesium.binding/defconsts clojure.core/declare
+           com.gfredericks.test.chuck.clojure-test/for-all clojure.core/for
+           com.gfredericks.test.chuck.properties/for-all clojure.core/for}
  :linters
   {:unresolved-symbol
     {:exclude [(caesium.binding/call!)]}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {caesium.binding/defconsts clojure.core/declare}
+ :linters
+  {:unresolved-symbol
+    {:exclude [(caesium.binding/call!)]}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,5 +2,9 @@
            com.gfredericks.test.chuck.clojure-test/for-all clojure.core/for
            com.gfredericks.test.chuck.properties/for-all clojure.core/for}
  :linters
-  {:unresolved-symbol
-    {:exclude [(caesium.binding/call!)]}}}
+ {:deprecated-var
+  {:exclude
+   {caesium.crypto.sign/generate-signing-keys
+    {:namespaces [caesium.crypto.sign-test]}}}
+  :unresolved-symbol
+  {:exclude [(caesium.binding/call!)]}}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
       run: lein with-profile +test kibit
     - name: Lint the code with Eastwood
       run: lein with-profile +test eastwood || true
+    - name: Lint the code with clj-kondo
+      run: lein with-profile +test clj-kondo --lint src:test || true
     - name: Check the dependencies are up-to-date
       run: lein with-profile +test ancient || true
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.class
 *.jar
 .DS_Store
+/.clj-kondo/.cache
 /.eastwood
 /.lein-*
 /.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,9 @@
              :dev {:dependencies [[criterium "0.4.5"]
                                   [org.clojure/test.check "1.0.0"]
                                   [com.gfredericks/test.chuck "0.2.10"]]}
-             :test {:plugins [[lein-ancient "0.6.15"]
+             :test {:aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]}
+                    :dependencies [[clj-kondo "RELEASE"]]
+                    :plugins [[lein-ancient "0.6.15"]
                               [lein-cljfmt "0.6.6"]
                               [lein-kibit "0.1.8"]
                               [jonase/eastwood "0.3.7"]

--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -715,7 +715,8 @@
   ([lib]
    (try
      (->
-      (LibraryLoader/create Sodium)
+      (LibraryLoader/create
+       #_{:clj-kondo/ignore [:unresolved-symbol]} Sodium)
       (.option LibraryOption/IgnoreError true)
       (.load lib))
      (catch Exception e

--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -6,8 +6,7 @@
   namespaces."
   (:require [clojure.string :as s]
             [clojure.math.combinatorics :as c]
-            [medley.core :as m]
-            [clojure.string :as str])
+            [medley.core :as m])
   (:import [jnr.ffi LibraryLoader LibraryOption]
            [jnr.ffi.annotations In Out Pinned LongLong]
            [jnr.ffi.types size_t]))
@@ -733,7 +732,7 @@
   crypto_generichash_generichash."
   [^clojure.lang.Namespace namespace ^clojure.lang.Symbol fn-name]
   (let [fn-name (s/replace (name fn-name) "-" "_")
-        fn-name-parts (set (str/split fn-name #"_"))
+        fn-name-parts (set (s/split fn-name #"_"))
         prefix (-> namespace ns-name str (s/split #"\.") rest vec)
         path (concat (remove fn-name-parts prefix) [fn-name])]
     (symbol (s/join "_" path))))
@@ -775,7 +774,7 @@
                       (with-meta arg {:tag (tag arg)})
 
                       (= 'long (tag arg))
-                      (let [arg-sym (symbol (str/replace (name arg) #"len$" ""))]
+                      (let [arg-sym (symbol (s/replace (name arg) #"len$" ""))]
                         `(long (caesium.byte-bufs/buflen ~arg-sym)))
 
                       (= 'jnr.ffi.byref.LongLongByReference (tag arg))

--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -8,8 +8,13 @@
             [clojure.math.combinatorics :as c]
             [medley.core :as m])
   (:import [jnr.ffi LibraryLoader LibraryOption]
-           [jnr.ffi.annotations In Out Pinned LongLong]
-           [jnr.ffi.types size_t]))
+           [jnr.ffi.annotations
+            #_{:clj-kondo/ignore [:unused-import]} In
+            #_{:clj-kondo/ignore [:unused-import]} Out
+            #_{:clj-kondo/ignore [:unused-import]} Pinned
+            #_{:clj-kondo/ignore [:unused-import]} LongLong]
+           [jnr.ffi.types
+            #_{:clj-kondo/ignore [:unused-import]} size_t]))
 
 (def ^:private bound-byte-type-syms
   '[bytes java.nio.ByteBuffer])

--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -719,7 +719,7 @@
        #_{:clj-kondo/ignore [:unresolved-symbol]} Sodium)
       (.option LibraryOption/IgnoreError true)
       (.load lib))
-     (catch Exception e
+     (catch Exception _
        (throw (ClassNotFoundException. "unable to load native libsodium; is it installed?"))))))
 
 (def ^Sodium sodium

--- a/src/caesium/crypto/aead.clj
+++ b/src/caesium/crypto/aead.clj
@@ -3,6 +3,19 @@
             [caesium.byte-bufs :as bb]
             [caesium.randombytes :as r]))
 
+(declare chacha20poly1305-ietf-keybytes
+         chacha20poly1305-ietf-nsecbytes
+         chacha20poly1305-ietf-npubbytes
+         chacha20poly1305-ietf-abytes
+         chacha20poly1305-keybytes
+         chacha20poly1305-nsecbytes
+         chacha20poly1305-npubbytes
+         chacha20poly1305-abytes
+         xchacha20poly1305-ietf-keybytes
+         xchacha20poly1305-ietf-nsecbytes
+         xchacha20poly1305-ietf-npubbytes
+         xchacha20poly1305-ietf-abytes)
+
 (b/defconsts [chacha20poly1305-ietf-keybytes
               chacha20poly1305-ietf-nsecbytes
               chacha20poly1305-ietf-npubbytes

--- a/src/caesium/crypto/auth.clj
+++ b/src/caesium/crypto/auth.clj
@@ -2,6 +2,10 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare hmacsha256-bytes hmacsha256-keybytes
+         hmacsha512-bytes hmacsha512-keybytes
+         hmacsha512256-bytes hmacsha512256-keybytes)
+
 (b/defconsts [hmacsha256-bytes hmacsha256-keybytes
               hmacsha512-bytes hmacsha512-keybytes
               hmacsha512256-bytes hmacsha512256-keybytes])

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -5,6 +5,14 @@
             [caesium.byte-bufs :as bb])
   (:import [java.nio ByteBuffer]))
 
+(declare seedbytes
+         publickeybytes
+         secretkeybytes
+         noncebytes
+         macbytes
+         sealbytes
+         primitive)
+
 (b/defconsts [seedbytes
               publickeybytes
               secretkeybytes

--- a/src/caesium/crypto/box.clj
+++ b/src/caesium/crypto/box.clj
@@ -2,8 +2,7 @@
   "Bindings to the public key authenticated encryption scheme."
   (:require [caesium.binding :as b]
             [caesium.crypto.scalarmult :as s]
-            [caesium.byte-bufs :as bb])
-  (:import [java.nio ByteBuffer]))
+            [caesium.byte-bufs :as bb]))
 
 (declare seedbytes
          publickeybytes

--- a/src/caesium/crypto/core/ristretto255.clj
+++ b/src/caesium/crypto/core/ristretto255.clj
@@ -8,6 +8,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes hashbytes scalarbytes nonreducedscalarbytes)
 (b/defconsts [bytes hashbytes scalarbytes nonreducedscalarbytes])
 
 (defn ^:private valid-point-in-buf?

--- a/src/caesium/crypto/generichash.clj
+++ b/src/caesium/crypto/generichash.clj
@@ -4,6 +4,21 @@
             [caesium.byte-bufs :as bb]
             [medley.core :as m]))
 
+(declare bytes
+         bytes-min
+         bytes-max
+         keybytes
+         keybytes-min
+         keybytes-max
+         blake2b-bytes
+         blake2b-bytes-min
+         blake2b-bytes-max
+         blake2b-keybytes
+         blake2b-keybytes-min
+         blake2b-keybytes-max
+         blake2b-saltbytes
+         blake2b-personalbytes)
+
 (b/defconsts [bytes
               bytes-min
               bytes-max

--- a/src/caesium/crypto/hash.clj
+++ b/src/caesium/crypto/hash.clj
@@ -2,6 +2,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare sha256-bytes sha512-bytes)
 (b/defconsts [sha256-bytes sha512-bytes])
 
 (defn sha256-to-buf!

--- a/src/caesium/crypto/kdf.clj
+++ b/src/caesium/crypto/kdf.clj
@@ -13,6 +13,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes-min bytes-max contextbytes keybytes primitive)
 (b/defconsts [bytes-min bytes-max contextbytes keybytes primitive])
 
 (defn ^:private keygen-to-buf

--- a/src/caesium/crypto/kx.clj
+++ b/src/caesium/crypto/kx.clj
@@ -4,6 +4,7 @@
             [caesium.byte-bufs :as bb])
   (:import [java.nio ByteBuffer]))
 
+(declare seedbytes publickeybytes secretkeybytes sessionkeybytes primitive)
 (b/defconsts [seedbytes publickeybytes secretkeybytes sessionkeybytes primitive])
 
 (defn keypair-to-buf!

--- a/src/caesium/crypto/kx.clj
+++ b/src/caesium/crypto/kx.clj
@@ -1,8 +1,7 @@
 (ns caesium.crypto.kx
   (:require [caesium.binding :as b]
             [caesium.crypto.scalarmult :as s]
-            [caesium.byte-bufs :as bb])
-  (:import [java.nio ByteBuffer]))
+            [caesium.byte-bufs :as bb]))
 
 (declare seedbytes publickeybytes secretkeybytes sessionkeybytes primitive)
 (b/defconsts [seedbytes publickeybytes secretkeybytes sessionkeybytes primitive])

--- a/src/caesium/crypto/pwhash.clj
+++ b/src/caesium/crypto/pwhash.clj
@@ -1,9 +1,7 @@
 (ns caesium.crypto.pwhash
   (:refer-clojure :exclude [bytes hash])
   (:require [caesium.binding :as b]
-            [caesium.byte-bufs :as bb]
-            [caesium.util :as u]
-            [medley.core :as m]))
+            [caesium.byte-bufs :as bb]))
 
 (declare alg-argon2i13
          alg-argon2id13

--- a/src/caesium/crypto/pwhash.clj
+++ b/src/caesium/crypto/pwhash.clj
@@ -5,6 +5,82 @@
             [caesium.util :as u]
             [medley.core :as m]))
 
+(declare alg-argon2i13
+         alg-argon2id13
+         alg-default
+         bytes-min
+         bytes-max
+         passwd-min
+         passwd-max
+         saltbytes
+         strbytes
+         strprefix
+         opslimit-min
+         opslimit-max
+         memlimit-min
+         memlimit-max
+         opslimit-interactive
+         memlimit-interactive
+         opslimit-moderate
+         memlimit-moderate
+         opslimit-sensitive
+         memlimit-sensitive
+         primitive
+
+         argon2i-alg-argon2i13
+         argon2i-bytes-min
+         argon2i-bytes-max
+         argon2i-passwd-min
+         argon2i-passwd-max
+         argon2i-saltbytes
+         argon2i-strbytes
+         argon2i-strprefix
+         argon2i-opslimit-min
+         argon2i-opslimit-max
+         argon2i-memlimit-min
+         argon2i-memlimit-max
+         argon2i-opslimit-interactive
+         argon2i-memlimit-interactive
+         argon2i-opslimit-moderate
+         argon2i-memlimit-moderate
+         argon2i-opslimit-sensitive
+         argon2i-memlimit-sensitive
+
+         argon2id-alg-argon2id13
+         argon2id-bytes-min
+         argon2id-bytes-max
+         argon2id-passwd-min
+         argon2id-passwd-max
+         argon2id-saltbytes
+         argon2id-strbytes
+         argon2id-strprefix
+         argon2id-opslimit-min
+         argon2id-opslimit-max
+         argon2id-memlimit-min
+         argon2id-memlimit-max
+         argon2id-opslimit-interactive
+         argon2id-memlimit-interactive
+         argon2id-opslimit-moderate
+         argon2id-memlimit-moderate
+         argon2id-opslimit-sensitive
+         argon2id-memlimit-sensitive
+
+         scryptsalsa208sha256-bytes-min
+         scryptsalsa208sha256-bytes-max
+         scryptsalsa208sha256-passwd-min
+         scryptsalsa208sha256-passwd-max
+         scryptsalsa208sha256-saltbytes
+         scryptsalsa208sha256-strbytes
+         scryptsalsa208sha256-strprefix
+         scryptsalsa208sha256-opslimit-min
+         scryptsalsa208sha256-opslimit-max
+         scryptsalsa208sha256-memlimit-min
+         scryptsalsa208sha256-memlimit-max
+         scryptsalsa208sha256-opslimit-interactive
+         scryptsalsa208sha256-memlimit-interactive
+         scryptsalsa208sha256-opslimit-sensitive
+         scryptsalsa208sha256-memlimit-sensitive)
+
 (b/defconsts [alg-argon2i13
               alg-argon2id13
               alg-default

--- a/src/caesium/crypto/scalarmult.clj
+++ b/src/caesium/crypto/scalarmult.clj
@@ -8,6 +8,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes scalarbytes primitive)
 (b/defconsts [bytes scalarbytes primitive])
 
 (defn scalarmult-to-buf!

--- a/src/caesium/crypto/scalarmult/ristretto255.clj
+++ b/src/caesium/crypto/scalarmult/ristretto255.clj
@@ -8,6 +8,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes scalarbytes)
 (b/defconsts [bytes scalarbytes])
 
 (defn scalarmult-to-buf!

--- a/src/caesium/crypto/secretbox.clj
+++ b/src/caesium/crypto/secretbox.clj
@@ -6,6 +6,7 @@
             [caesium.randombytes :as r])
   (:import [java.nio ByteBuffer]))
 
+(declare keybytes noncebytes macbytes primitive)
 (b/defconsts [keybytes noncebytes macbytes primitive])
 
 (defn secretbox-easy-to-buf!

--- a/src/caesium/crypto/secretbox.clj
+++ b/src/caesium/crypto/secretbox.clj
@@ -3,8 +3,7 @@
   (:require [caesium.binding :as b]
             [caesium.util :as u]
             [caesium.byte-bufs :as bb]
-            [caesium.randombytes :as r])
-  (:import [java.nio ByteBuffer]))
+            [caesium.randombytes :as r]))
 
 (declare keybytes noncebytes macbytes primitive)
 (b/defconsts [keybytes noncebytes macbytes primitive])

--- a/src/caesium/crypto/shorthash.clj
+++ b/src/caesium/crypto/shorthash.clj
@@ -3,6 +3,10 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes
+         keybytes
+         primitive)
+
 (b/defconsts [bytes
               keybytes
               primitive])

--- a/src/caesium/crypto/sign.clj
+++ b/src/caesium/crypto/sign.clj
@@ -3,6 +3,7 @@
   (:require [caesium.binding :as b]
             [caesium.byte-bufs :as bb]))
 
+(declare bytes seedbytes publickeybytes secretkeybytes primitive)
 (b/defconsts [bytes seedbytes publickeybytes secretkeybytes primitive])
 
 (defn keypair!

--- a/src/caesium/util.clj
+++ b/src/caesium/util.clj
@@ -3,8 +3,8 @@
 
   This ns is not considered public API, and may break without semver
   major version increments."
-  (:import (java.util Arrays)
-           (org.apache.commons.codec.binary Hex)))
+  (:import
+   [org.apache.commons.codec.binary Hex]))
 
 (defn unhexify
   [^String s]

--- a/test/caesium/binding_test.clj
+++ b/test/caesium/binding_test.clj
@@ -4,8 +4,8 @@
             [clojure.test :refer [deftest is are]])
   (:import [caesium.binding Sodium]
            [java.lang.annotation Annotation]
-           [java.lang.reflect Method Type AnnotatedElement]
-           [jnr.ffi.annotations In Out Pinned LongLong]
+           [java.lang.reflect Method]
+           [jnr.ffi.annotations Pinned LongLong]
            [jnr.ffi.byref LongLongByReference]
            [java.nio ByteBuffer]
            [jnr.ffi.types size_t]))

--- a/test/caesium/byte_bufs_test.clj
+++ b/test/caesium/byte_bufs_test.clj
@@ -1,6 +1,6 @@
 (ns caesium.byte-bufs-test
   (:require [caesium.byte-bufs :as bb]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [is]]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [for-all]]

--- a/test/caesium/byte_bufs_test.clj
+++ b/test/caesium/byte_bufs_test.clj
@@ -51,8 +51,6 @@
   1000
   (prop'/for-all
    [n gen/nat
-    start (gen/choose 0 n)
-    end (gen/choose start n)
     g (gen/elements ways-of-getting-a-buf-of-len-n)]
    (= n (bb/buflen (g n)))))
 

--- a/test/caesium/byte_bufs_test.clj
+++ b/test/caesium/byte_bufs_test.clj
@@ -14,7 +14,7 @@
    (fn [n] (ByteBuffer/allocateDirect n))
    (fn [n] (ByteBuffer/wrap (byte-array n)))])
 
-(defspec ->indirect-byte-buf-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} ->indirect-byte-buf-spec
   1000
   (for-all
    [n gen/nat
@@ -27,7 +27,7 @@
      ;; when the input is a byte buffer, don't convert
      (is (not (.isDirect ^ByteBuffer buf))))))
 
-(defspec ->direct-byte-buf-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} ->direct-byte-buf-spec
   1000
   (for-all
    [n gen/nat
@@ -40,14 +40,14 @@
      ;; when the input is a byte buffer, don't convert
      (is (.isDirect ^ByteBuffer buf)))))
 
-(defspec buflen-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} buflen-spec
   1000
   (prop'/for-all
    [n gen/nat
     g (gen/elements ways-of-getting-a-buf-of-len-n)]
    (= n (bb/buflen (g n)))))
 
-(defspec slice-buflen-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} slice-buflen-spec
   1000
   (prop'/for-all
    [n gen/nat
@@ -56,7 +56,7 @@
     g (gen/elements ways-of-getting-a-buf-of-len-n)]
    (= n (bb/buflen (g n)))))
 
-(defspec wrapped-array-buflen-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} wrapped-array-buflen-spec
   1000
   (prop'/for-all
    [n gen/nat
@@ -67,7 +67,7 @@
           (ByteBuffer/wrap start slicelen)
           (bb/buflen)))))
 
-(defspec alloc-spec
+(defspec #_{:clj-kondo/ignore [:unresolved-symbol]} alloc-spec
   1000
   (prop'/for-all
    [n gen/nat]

--- a/test/caesium/crypto/aead_test.clj
+++ b/test/caesium/crypto/aead_test.clj
@@ -3,6 +3,7 @@
             [caesium.test-utils :refer [const-test]]
             [caesium.vectors :as v]
             [clojure.test :refer [is deftest]]
+            [clojure.string]
             [caesium.byte-bufs :as bb]
             [caesium.randombytes :as r])
   (:import (java.nio ByteBuffer)))

--- a/test/caesium/crypto/box_test.clj
+++ b/test/caesium/crypto/box_test.clj
@@ -1,9 +1,9 @@
+
 (ns caesium.crypto.box-test
   (:require [caesium.crypto.box :as b]
             [caesium.byte-bufs :as bb]
             [caesium.randombytes :as r]
             [caesium.test-utils :refer [const-test]]
-            [caesium.util :as u]
             [caesium.vectors :as v]
             [clojure.test :refer [deftest is testing]]))
 

--- a/test/caesium/crypto/pwhash_test.clj
+++ b/test/caesium/crypto/pwhash_test.clj
@@ -1,11 +1,8 @@
 (ns caesium.crypto.pwhash-test
   (:require [caesium.crypto.pwhash :as p]
-            [caesium.byte-bufs :as bb]
             [caesium.test-utils :refer [const-test]]
-            [caesium.vectors :as v]
             [caesium.util :as u]
-            [caesium.randombytes :as r]
-            [clojure.test :refer [are deftest is]]))
+            [clojure.test :refer [deftest is]]))
 
 (const-test
  p/alg-argon2i13 1

--- a/test/caesium/crypto/scalarmult/ristretto255_test.clj
+++ b/test/caesium/crypto/scalarmult/ristretto255_test.clj
@@ -6,7 +6,7 @@
             [caesium.test-utils :refer [const-test]]
             [caesium.util :as u]
             [caesium.vectors :as v]
-            [clojure.test :refer [are deftest is testing]]))
+            [clojure.test :refer [deftest is testing]]))
 
 (const-test
  s/bytes 32

--- a/test/caesium/crypto/secretbox_test.clj
+++ b/test/caesium/crypto/secretbox_test.clj
@@ -1,7 +1,6 @@
 (ns caesium.crypto.secretbox-test
   (:require [caesium.crypto.secretbox :as s]
             [caesium.test-utils :refer [const-test]]
-            [caesium.util :as u]
             [caesium.vectors :as v]
             [clojure.test :refer [is are deftest testing]]
             [caesium.byte-bufs :as bb]))

--- a/test/caesium/crypto/shorthash_test.clj
+++ b/test/caesium/crypto/shorthash_test.clj
@@ -1,6 +1,6 @@
 (ns caesium.crypto.shorthash-test
   (:require [caesium.crypto.shorthash :as sh]
-            [clojure.test :refer [is testing deftest]]
+            [clojure.test :refer [is deftest]]
             [caesium.test-utils :refer [const-test]]
             [caesium.byte-bufs :as bb]
             [caesium.vectors :as v]))

--- a/test/caesium/crypto/sign_test.clj
+++ b/test/caesium/crypto/sign_test.clj
@@ -43,7 +43,7 @@
     (is (nil? (s/verify (s/sign message sk) message pk))))
   (is (thrown-with-msg?
        RuntimeException #"^Signature validation failed$"
-       (let [{pk :public sk :secret} (s/keypair!)
+       (let [{_pk :public sk :secret} (s/keypair!)
              other-sig (s/sign message sk)]
          (s/verify other-sig message public)))))
 
@@ -54,6 +54,6 @@
   (is (bb/bytes= message (s/verify signed public)))
   (is (thrown-with-msg?
        RuntimeException #"^Signature validation failed$"
-       (let [{pk :public sk :secret} (s/keypair!)
+       (let [{_pk :public sk :secret} (s/keypair!)
              other-signed (s/signed message sk)]
          (s/verify other-signed public)))))

--- a/test/caesium/crypto/sign_test.clj
+++ b/test/caesium/crypto/sign_test.clj
@@ -2,7 +2,7 @@
   (:require [caesium.crypto.sign :as s]
             [caesium.byte-bufs :as bb]
             [caesium.vectors :refer [hex-resource]]
-            [clojure.test :refer [deftest is testing]]
+            [clojure.test :refer [deftest is]]
             [caesium.test-utils :refer [const-test]]))
 
 (const-test

--- a/test/caesium/magicnonce/secretbox_test.clj
+++ b/test/caesium/magicnonce/secretbox_test.clj
@@ -4,7 +4,6 @@
             [caesium.crypto.secretbox-test :as st]
             [clojure.test :refer [deftest is]]
             [caesium.randombytes :as r]
-            [caesium.util :as u]
             [caesium.crypto.generichash :as g]
             [caesium.byte-bufs :as bb]))
 

--- a/test/caesium/randombytes_test.clj
+++ b/test/caesium/randombytes_test.clj
@@ -1,8 +1,7 @@
 (ns caesium.randombytes-test
   (:require [caesium.randombytes :as r]
             [clojure.test :refer [deftest is]]
-            [caesium.byte-bufs :as bb])
-  (:import (java.nio ByteBuffer)))
+            [caesium.byte-bufs :as bb]))
 
 (deftest randombytes-test
   (let [buf (r/randombytes 10)]


### PR DESCRIPTION
### Where it all started

> FWIW, I would completely understand if you want to fix Eastwood first, but I've had mostly a good time with clj-kondo. https://github.com/latacora/wernicke has example workflows (in GitHub Actions, though: not Travis). I'm fine with Eastwood too! But mostly don't feel like you have to get Eastwood working because that's what was there :)

The preference isn't a strong ground to change the tool, albeit I tend to use clj-kondo in my other projects as well. :) The warnings were quite easy to fix, so just sticking with it is fine I guess for now. I doubt clj-kondo will be any different in terms of integrating in GH Actions later. Please tell me if you'd like eastwood replaced and we can look into it at a later stage.

_Originally posted by @eploko in https://github.com/lvh/caesium/pull/69#issuecomment-690807129_

### What this PR brings

This adds clj-kondo as a dependency for the test profile. It also adds a step to the build workflow to lint the code with clj-kondo. The step is postfixed with `|| true` a là the eastwood step so it doesn't fail the build.

### Things to do before merging this in

- [x] Fix all of the issues reported by clj-kondo.
- [x] Decide whether we remove eastwood after integrating clj-kondo.
