### PR TITLE
Don't swallow exceptions when caesium fails to load

### DIFF
--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -715,7 +715,7 @@
       (.option LibraryOption/IgnoreError true)
       (.load lib))
      (catch Exception e
-       (throw (ClassNotFoundException. "unable to load native libsodium; is it installed?"))))))
+       (throw (ClassNotFoundException. "unable to load native libsodium; is it installed?" e))))))
 
 (def ^Sodium sodium
   "The sodium library singleton instance."


### PR DESCRIPTION
Rethrow the caught exception. In my case, this was swallowing a useful exception while AOTing:

```
{:clojure.main/message
 "Execution error (MethodTooLargeException) at jdk.internal.org.objectweb.asm.MethodWriter/computeMethodInfoSize (MethodWriter.java:2120).\nMethod too large: com/sun/proxy/$Proxy4.<clinit> ()V\n",
 :clojure.main/triage
 {:clojure.error/class
  jdk.internal.org.objectweb.asm.MethodTooLargeException,
  :clojure.error/line 2120,
  :clojure.error/cause
  "Method too large: com/sun/proxy/$Proxy4.<clinit> ()V",
  :clojure.error/symbol
  jdk.internal.org.objectweb.asm.MethodWriter/computeMethodInfoSize,
  :clojure.error/source "MethodWriter.java",
  :clojure.error/phase :execution},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message "Syntax error macroexpanding at (binding.clj:722:3).",
    :data
    {:clojure.error/phase :execution,
     :clojure.error/line 722,
     :clojure.error/column 3,
     :clojure.error/source "binding.clj"},
    :at [clojure.lang.Compiler$InvokeExpr eval "Compiler.java" 3711]}
   {:type java.lang.ClassNotFoundException,
    :message "unable to load native libsodium; is it installed?",
    :at [caesium.binding$load_sodium invokeStatic "binding.clj" 716]}
   {:type jdk.internal.org.objectweb.asm.MethodTooLargeException,
    :message "Method too large: com/sun/proxy/$Proxy4.<clinit> ()V",
    :at
    [jdk.internal.org.objectweb.asm.MethodWriter
     computeMethodInfoSize
     "MethodWriter.java"
     2120]}],

```