### PR TITLE
Fail immediately for more informative errors

### DIFF
--- a/src/caesium/binding.clj
+++ b/src/caesium/binding.clj
@@ -712,7 +712,7 @@
    (try
      (->
       (LibraryLoader/create Sodium)
-      (.option LibraryOption/IgnoreError true)
+      (.failImmediately)
       (.load lib))
      (catch Exception e
        (throw (ClassNotFoundException. "unable to load native libsodium; is it installed?" e))))))

--- a/test/caesium/binding_test.clj
+++ b/test/caesium/binding_test.clj
@@ -11,8 +11,8 @@
            [jnr.ffi.types size_t]))
 
 (deftest library-not-installed-test
-  (let [result (try (#'b/load-sodium "notsodium-801a67af") (catch Exception e e))]
-    (is (= (type result) (type (ClassNotFoundException.))))))
+  (let [result (try (#'b/load-sodium "notsodium-801a67af") (catch Throwable t t))]
+    (is (= (type result) (type (UnsatisfiedLinkError.))))))
 
 (deftest permuted-byte-types-test
   (is (= '[[^long ^{size_t {}} crypto_secretbox_keybytes []]]


### PR DESCRIPTION
Change the option when the native library fails to load, for better error reporting:

```
#error {
 :cause unable to load native libsodium; is it installed?
 :via
 [{:type clojure.lang.ExceptionInfo
   :message exception while compiling
   :data {:request {:aot-nses [caesium.binding], :classes-dir bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes, :classpath [external/deps/repository/caesium/caesium/0.13.0/caesium-0.13.0.jar external/deps/repository/org/clojure/clojure/1.11.1/clojure-1.11.1.jar external/deps/repository/org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.jar external/deps/repository/org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.jar external/deps/repository/com/github/jnr/jnr-ffi/2.2.12/jnr-ffi-2.2.12.jar external/deps/repository/com/github/jnr/jffi/1.3.9/jffi-1.3.9-native.jar external/deps/repository/org/ow2/asm/asm-util/9.2/asm-util-9.2.jar external/deps/repository/org/ow2/asm/asm/9.2/asm-9.2.jar external/deps/repository/org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2.jar external/deps/repository/org/ow2/asm/asm-tree/9.2/asm-tree-9.2.jar external/deps/repository/com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0.jar external/deps/repository/org/ow2/asm/asm-commons/9.2/asm-commons-9.2.jar external/deps/repository/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar external/deps/repository/com/github/jnr/jffi/1.3.9/jffi-1.3.9.jar external/deps/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar external/deps/repository/byte-streams/byte-streams/0.2.4/byte-streams-0.2.4.jar external/deps/repository/manifold/manifold/0.1.9/manifold-0.1.9.jar external/deps/repository/org/clojure/tools.logging/1.1.0/tools.logging-1.1.0.jar external/deps/repository/io/aleph/dirigiste/1.0.0/dirigiste-1.0.0.jar external/deps/repository/riddley/riddley/0.1.15/riddley-0.1.15.jar external/deps/repository/primitive-math/primitive-math/0.1.6/primitive-math-0.1.6.jar external/deps/repository/clj-tuple/clj-tuple/0.2.2/clj-tuple-0.2.2.jar external/deps/repository/com/taoensso/timbre/4.10.0/timbre-4.10.0.jar external/deps/repository/com/taoensso/encore/2.91.0/encore-2.91.0.jar external/deps/repository/com/taoensso/truss/1.5.0/truss-1.5.0.jar external/deps/repository/org/clojure/tools.reader/1.3.4/tools.reader-1.3.4.jar external/deps/repository/io/aviso/pretty/0.1.33/pretty-0.1.33.jar external/deps/repository/org/clojure/math.combinatorics/0.1.6/math.combinatorics-0.1.6.jar external/deps/repository/medley/medley/1.3.0/medley-1.3.0.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_org_clojure_math_combinatorics_clojure_math_combinatorics.jar bazel-out/darwin_arm64-fastbuild/bin/external/rules_clojure/src/rules_clojure/libcompile.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_medley_medley_medley_core.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes], :output-jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_caesium_caesium_caesium_binding.jar, :resources [], :src-dir nil, :srcs [], :classloader-strategy #object[rules_clojure.persistent_classloader$caching_clean_GAV_thread_local$reify__3858 0x28af4e1e rules_clojure.persistent_classloader$caching_clean_GAV_thread_local$reify__3858@28af4e1e]}, :script (do (clojure.core/let [ns__3958__auto__ (clojure.core/create-ns (quote G__56765))] (clojure.core/binding [clojure.core/*ns* ns__3958__auto__ clojure.core/*compile-path* (clojure.core/str "bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes" "/")] (clojure.core/let [rets__3957__auto__ [(do (clojure.core/require (quote rules-clojure.compile)) (clojure.core/let [ntc__3956__auto__ (clojure.core/ns-resolve (quote rules-clojure.compile) (quote non-transitive-compile-json))] (clojure.core/assert ntc__3956__auto__) (ntc__3956__auto__ (quote (medley.core clojure.math.combinatorics clojure.string)) (quote caesium.binding))))]] (clojure.core/some clojure.core/identity rets__3957__auto__)))))}
   :at [rules_clojure.worker$process_request invokeStatic worker.clj 57]}
  {:type java.lang.reflect.InvocationTargetException
   :message nil
   :at [jdk.internal.reflect.NativeMethodAccessorImpl invoke0 NativeMethodAccessorImpl.java -2]}
  {:type clojure.lang.ExceptionInfo
   :message while compiling
   :at [rules_clojure.compile$unconditional_compile invokeStatic compile.clj 105]}
  {:type clojure.lang.Compiler$CompilerException
   :message Syntax error macroexpanding at (binding.clj:649:3).
   :at [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3719]}
  {:type java.lang.ClassNotFoundException
   :message unable to load native libsodium; is it installed?
   :at [caesium.binding$load_sodium invokeStatic binding.clj 643]}]
 :trace
```

Becomes
```
#error {
 :cause dlopen(/Users/arohner/Library/Java/Extensions/libsodium.dylib, 0x0009): tried: '/Users/arohner/Library/Java/Extensions/libsodium.dylib' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))), '/usr/local/Cellar/libsodium/1.0.18_1/lib/libsodium.23.dylib' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)))
Library names
[sodium]
Search paths:
[/Users/arohner/Library/Java/Extensions, /Library/Java/Extensions, /Network/Library/Java/Extensions, /System/Library/Java/Extensions, /usr/lib/java, ., /usr/local/lib, /usr/lib, /lib]
 :via
 [{:type clojure.lang.ExceptionInfo
   :message exception while compiling
   :data {:request {:aot-nses [caesium.binding], :classes-dir bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes, :classpath [external/deps/repository/caesium/caesium/0.15.0-griffin-errors/caesium-0.15.0-griffin-errors.jar external/deps/repository/org/clojure/clojure/1.11.1/clojure-1.11.1.jar external/deps/repository/org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.jar external/deps/repository/org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.jar external/deps/repository/com/github/jnr/jnr-ffi/2.2.12/jnr-ffi-2.2.12.jar external/deps/repository/com/github/jnr/jffi/1.3.9/jffi-1.3.9-native.jar external/deps/repository/org/ow2/asm/asm-util/9.2/asm-util-9.2.jar external/deps/repository/org/ow2/asm/asm/9.2/asm-9.2.jar external/deps/repository/org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2.jar external/deps/repository/org/ow2/asm/asm-tree/9.2/asm-tree-9.2.jar external/deps/repository/com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0.jar external/deps/repository/org/ow2/asm/asm-commons/9.2/asm-commons-9.2.jar external/deps/repository/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar external/deps/repository/com/github/jnr/jffi/1.3.9/jffi-1.3.9.jar external/deps/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar external/deps/repository/byte-streams/byte-streams/0.2.4/byte-streams-0.2.4.jar external/deps/repository/manifold/manifold/0.1.9/manifold-0.1.9.jar external/deps/repository/org/clojure/tools.logging/1.1.0/tools.logging-1.1.0.jar external/deps/repository/io/aleph/dirigiste/1.0.0/dirigiste-1.0.0.jar external/deps/repository/riddley/riddley/0.1.15/riddley-0.1.15.jar external/deps/repository/primitive-math/primitive-math/0.1.6/primitive-math-0.1.6.jar external/deps/repository/clj-tuple/clj-tuple/0.2.2/clj-tuple-0.2.2.jar external/deps/repository/com/taoensso/timbre/4.10.0/timbre-4.10.0.jar external/deps/repository/com/taoensso/encore/2.91.0/encore-2.91.0.jar external/deps/repository/com/taoensso/truss/1.5.0/truss-1.5.0.jar external/deps/repository/org/clojure/tools.reader/1.3.4/tools.reader-1.3.4.jar external/deps/repository/io/aviso/pretty/0.1.33/pretty-0.1.33.jar external/deps/repository/org/clojure/math.combinatorics/0.1.6/math.combinatorics-0.1.6.jar external/deps/repository/medley/medley/1.3.0/medley-1.3.0.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_org_clojure_math_combinatorics_clojure_math_combinatorics.jar bazel-out/darwin_arm64-fastbuild/bin/external/rules_clojure/src/rules_clojure/libcompile.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_medley_medley_medley_core.jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes], :output-jar bazel-out/darwin_arm64-fastbuild/bin/external/deps/ns_caesium_caesium_caesium_binding.jar, :resources [], :src-dir nil, :srcs [], :classloader-strategy #object[rules_clojure.persistent_classloader$caching_clean_GAV_thread_local$reify__3858 0xb26718f rules_clojure.persistent_classloader$caching_clean_GAV_thread_local$reify__3858@b26718f]}, :script (do (clojure.core/let [ns__3958__auto__ (clojure.core/create-ns (quote G__2944))] (clojure.core/binding [clojure.core/*ns* ns__3958__auto__ clojure.core/*compile-path* (clojure.core/str "bazel-out/darwin_arm64-fastbuild/bin/external/deps/.ns_caesium_caesium_caesium_binding.classes" "/")] (clojure.core/let [rets__3957__auto__ [(do (clojure.core/require (quote rules-clojure.compile)) (clojure.core/let [ntc__3956__auto__ (clojure.core/ns-resolve (quote rules-clojure.compile) (quote non-transitive-compile-json))] (clojure.core/assert ntc__3956__auto__) (ntc__3956__auto__ (quote (medley.core clojure.math.combinatorics clojure.string)) (quote caesium.binding))))]] (clojure.core/some clojure.core/identity rets__3957__auto__)))))}
   :at [rules_clojure.worker$process_request invokeStatic worker.clj 57]}
  {:type java.lang.reflect.InvocationTargetException
   :message nil
   :at [jdk.internal.reflect.NativeMethodAccessorImpl invoke0 NativeMethodAccessorImpl.java -2]}
  {:type clojure.lang.ExceptionInfo
   :message while compiling
   :at [rules_clojure.compile$unconditional_compile invokeStatic compile.clj 105]}
  {:type clojure.lang.Compiler$CompilerException
   :message Syntax error macroexpanding at (binding.clj:722:3).
   :at [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3719]}
  {:type java.lang.UnsatisfiedLinkError
   :message dlopen(/Users/arohner/Library/Java/Extensions/libsodium.dylib, 0x0009): tried: '/Users/arohner/Library/Java/Extensions/libsodium.dylib' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))), '/usr/local/Cellar/libsodium/1.0.18_1/lib/libsodium.23.dylib' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)))
Library names
[sodium]
Search paths:
[/Users/arohner/Library/Java/Extensions, /Library/Java/Extensions, /Network/Library/Java/Extensions, /System/Library/Java/Extensions, /usr/lib/java, ., /usr/local/lib, /usr/lib, /lib]
   :at [jnr.ffi.provider.jffi.NativeLibrary loadNativeLibraries NativeLibrary.java 111]}]
 :trace
```