### PR TITLE
Fix typo in README.md: msb to sb

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here's an example of how you can use pwhash:
 
 ;; key derivation
 (def salt (rb/randombytes pwhash/saltbytes)) ; changing salt means changed derived key
-(def derived-key (pwhash/pwhash msb/keybytes
+(def derived-key (pwhash/pwhash sb/keybytes
                                 password
                                 salt
                                 pwhash/opslimit-sensitive


### PR DESCRIPTION
Replace msb/keybytes with sb/keybytes (which is defined and probably intended)